### PR TITLE
add the possibility to inline documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0 - 26 August 2015
+### Minor
+- add the `inlinePath` conf option in order to inline docs
+
 ## 0.1.0 - Summer 2015
 ### Breaking
 - revamped and rewrote the whole projects in order to enable

--- a/configuration-examples/1.json
+++ b/configuration-examples/1.json
@@ -1,4 +1,5 @@
 {
   "recipients": ["+1234", "+56789"],
-  "template": "A new Ebola suspect was found, the id is ${ personId }"
+  "template": "A new Ebola suspect was found, the name is ${personId.otherNames} ${ personId.surname }",
+  "inlinePath": "personId"
 }

--- a/lib.js
+++ b/lib.js
@@ -1,7 +1,6 @@
 var assert = require('assert'),
     PouchDB = require('pouchdb'),
     _ = require('lodash'),
-    flatten = require('flat'),
     request = require('request'),
     raven = require('raven'),
     log = require('loglevel'),
@@ -106,7 +105,7 @@ function withOptions(options) {
 
 function dispatch(obj) {
   var render = _.template(obj.configurationDocument.template),
-      content = render(flatten(obj.change)),
+      content = render(obj.change),
       outgoing = obj.configurationDocument.recipients.map(function(recipient) {
         return {
           to: recipient,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sense-dispatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "messaging framework for eHealth Sense app.",
   "keywords": [
     "sense",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "peerDependencies": {},
   "dependencies": {
     "baconjs": "^0.7.71",
-    "flat": "^1.6.0",
     "lodash": "^3.10.1",
     "loglevel": "^1.3.1",
     "pouchdb": "^3.6.0",

--- a/sense-dispatch.js
+++ b/sense-dispatch.js
@@ -4,7 +4,7 @@ var yargs = require('yargs'),
     reactive = require('./reactive');
 
 var options = yargs
-      .version('0.1.0')
+      .version('0.2.0')
       .usage('Usage: $0 -d <database location> -g <gateway location>')
       .options({
         'd': {

--- a/test/main/lib.js
+++ b/test/main/lib.js
@@ -35,6 +35,21 @@ describe('the second library', function() {
         });
       }, 'persoId is not defined');
     });
+    it('ignores missing properties on the second level', function() {
+      var result = lib.dispatch({
+        configurationDocument: {
+          template: 'A new Ebola suspect was found, the id is ${ one.two }',
+          recipients: ['1234']
+        },
+        change: {
+          one: {}
+        }
+      });
+      assert.deepEqual(result, [{
+        to: '1234',
+        content: 'A new Ebola suspect was found, the id is '
+      }]);
+    });
   });
   describe('withOptions', function() {
     var withOptions;


### PR DESCRIPTION
This should allow to include info about a referenced document in the message to be sent. This way we might show personal information, see [the discussion on the dashboard issue](https://github.com/eHealthAfrica/sense-dashboard/issues/77#issuecomment-134585640). I could not test this with the actual servers today, because i was getting random server errors. See the conf example for info about how to use it.

This also shows how Bacon allows us to cleanly and efficiently add processing steps. I am not satisfied about this complex `obj` we are carrying along from one stage to the other, but i see no cleaner alternatives at the moment
