### PR TITLE
Inline, standardised.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0 - 26 August 2015
+### Minor
+- add the `inlinePath` conf option in order to inline docs
+
 ## 0.1.0 - Summer 2015
 ### Breaking
 - revamped and rewrote the whole projects in order to enable

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,52 +1,14 @@
-var fs = require('fs');
-var cp = require('child_process');
-var rimraf = require('rimraf');
-var istanbul = require('istanbul');
+var fs = require('fs')
+var cp = require('child_process')
+var rimraf = require('rimraf')
+var istanbul = require('istanbul')
 
-var LINT = true;
-var COVERALLS = false;
+var LINT = true
+var COVERALLS = false
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    jshint: {
-      options: { // see http://www.jshint.com/docs/options/
-        node: true,
-        esnext: true,
-        bitwise: true,
-        camelcase: true,
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        indent: 2,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        undef: true,
-        trailing: true,
-        smarttabs: true
-      },
-      build: ['Gruntfile.js'],
-      lib: ['index.js', 'lib/**/*.js'],
-      test: {
-        options: {
-          '-W030': true, // Expected an assignment or function call and instead saw an expression: ...to.be.true
-          globals: {
-            describe: true,
-            it: true,
-            assert: true,
-            expect: true,
-            before: true,
-            after: true,
-            beforeEach: true,
-            afterEach: true
-          }
-        },
-        files: {
-          src: ['test/**/*.js']
-        }
-      }
-    },
     mochaTest: {
       lib: {
         options: {
@@ -56,67 +18,65 @@ module.exports = function(grunt) {
         src: ['test/**/*.js', '!test/init.js', '!test/_fixtures/**']
       }
     }
-  });
+  })
 
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-mocha-test');
+  grunt.loadNpmTasks('grunt-mocha-test')
 
-  grunt.registerTask('test', 'Build, generate coverage, run tests.', function() {
+  grunt.registerTask('test', 'Build, generate coverage, run tests.', function () {
     if (fs.existsSync('test-results')) {
-      rimraf.sync('test-results');
+      rimraf.sync('test-results')
     }
-    fs.mkdirSync('test-results');
+    fs.mkdirSync('test-results')
 
-    process.env.multi = 'spec=- mocha-slow-reporter=test-results/slow.txt';
-    grunt.config.set('mochaTest.lib.options.reporter', 'mocha-multi');
+    process.env.multi = 'spec=- mocha-slow-reporter=test-results/slow.txt'
+    grunt.config.set('mochaTest.lib.options.reporter', 'mocha-multi')
 
     // needed so that mocha-multi doesn't kill the process
-    var program = require('mocha/node_modules/commander');
-    program.name = 'mocha';
-    program.exit = false;
+    var program = require('mocha/node_modules/commander')
+    program.name = 'mocha'
+    program.exit = false
 
-    grunt.task.run(['build', 'mochaTest', 'covreport']);
+    grunt.task.run(['build', 'mochaTest', 'covreport'])
     if (process.env.TRAVIS) {
-      grunt.config.set('mochaTest.lib.options.reporter', 'mocha-unfunk-reporter');
+      grunt.config.set('mochaTest.lib.options.reporter', 'mocha-unfunk-reporter')
       if (COVERALLS) {
-        grunt.task.run(['coveralls']);
+        grunt.task.run(['coveralls'])
       }
     }
-  });
+  })
 
-  grunt.registerTask('covreport', 'Generate coverage reports.', function() {
-    var collector = new istanbul.Collector();
-    collector.add(global.__coverage__);
+  grunt.registerTask('covreport', 'Generate coverage reports.', function () {
+    var collector = new istanbul.Collector()
+    collector.add(global.__coverage__)
     var reports = [
       istanbul.Report.create('lcovonly', { dir: 'test-results' })
-    ];
+    ]
     if (process.env.TRAVIS) {
       // show per-file coverage stats in the Travis console
-      reports.push(istanbul.Report.create('text'));
+      reports.push(istanbul.Report.create('text'))
     } else {
       // produce HTML when not running under Travis
-      reports.push(istanbul.Report.create('html', { dir: 'test-results' }));
+      reports.push(istanbul.Report.create('html', { dir: 'test-results' }))
     }
-    reports.push(istanbul.Report.create('text-summary'));
-    reports.forEach(function(report) {
-      report.writeReport(collector, true);
-    });
-  });
+    reports.push(istanbul.Report.create('text-summary'))
+    reports.forEach(function (report) {
+      report.writeReport(collector, true)
+    })
+  })
 
-  grunt.registerTask('coveralls', 'Push to Coveralls.', function() {
-    this.requires('mochaTest');
-    var done = this.async();
-    cp.exec('cat ./test-results/lcov.info | ./node_modules/.bin/coveralls', { cwd: './' }, function(err, stdout, stderr) {
-      grunt.log.writeln(stdout + stderr);
-      done(err);
-    });
-  });
+  grunt.registerTask('coveralls', 'Push to Coveralls.', function () {
+    this.requires('mochaTest')
+    var done = this.async()
+    cp.exec('cat ./test-results/lcov.info | ./node_modules/.bin/coveralls', { cwd: './' }, function (err, stdout, stderr) {
+      grunt.log.writeln(stdout + stderr)
+      done(err)
+    })
+  })
 
-  grunt.registerTask('build', function() {
+  grunt.registerTask('build', function () {
     if (LINT) {
-      grunt.task.run('jshint');
     }
-  });
+  })
 
-  grunt.registerTask('default', ['build']);
-};
+  grunt.registerTask('default', ['build'])
+}

--- a/configuration-examples/1.json
+++ b/configuration-examples/1.json
@@ -1,4 +1,5 @@
 {
   "recipients": ["+1234", "+56789"],
-  "template": "A new Ebola suspect was found, the id is ${ personId }"
+  "template": "A new Ebola suspect was found, the name is ${personId.otherNames} ${ personId.surname }",
+  "inlinePath": "personId"
 }

--- a/lib.js
+++ b/lib.js
@@ -1,7 +1,6 @@
 var assert = require('assert'),
     PouchDB = require('pouchdb'),
     _ = require('lodash'),
-    flatten = require('flat'),
     request = require('request'),
     raven = require('raven'),
     log = require('loglevel'),
@@ -106,7 +105,7 @@ function withOptions(options) {
 
 function dispatch(obj) {
   var render = _.template(obj.configurationDocument.template),
-      content = render(flatten(obj.change)),
+      content = render(obj.change),
       outgoing = obj.configurationDocument.recipients.map(function(recipient) {
         return {
           to: recipient,

--- a/package.json
+++ b/package.json
@@ -21,9 +21,18 @@
     "url": "https://github.com/eHealthAfrica/sense-dispatch/issues"
   },
   "bin": "./sense-dispatch.js",
+  "standard": {
+    "global": [
+      "describe",
+      "it",
+      "beforeEach",
+      "afterEach",
+      "assert"
+    ]
+  },
   "scripts": {
     "prepublish": "grunt build",
-    "test": "grunt test"
+    "test": "standard && grunt test"
   },
   "devDependencies": {
     "chai": "~1.8.1",
@@ -35,7 +44,8 @@
     "mocha-slow-reporter": "0.0.0",
     "mocha-unfunk-reporter": "~0.4.0",
     "rimraf": "~2.2.5",
-    "sinon": "^1.16.0"
+    "sinon": "^1.16.0",
+    "standard": "^5.1.0"
   },
   "peerDependencies": {},
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sense-dispatch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "messaging framework for eHealth Sense app.",
   "keywords": [
     "sense",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "peerDependencies": {},
   "dependencies": {
     "baconjs": "^0.7.71",
-    "flat": "^1.6.0",
     "lodash": "^3.10.1",
     "loglevel": "^1.3.1",
     "pouchdb": "^3.6.0",

--- a/reactive.js
+++ b/reactive.js
@@ -2,109 +2,109 @@
  * library into a single function to be run. i keep all code depending
  * on Bacon here, so if somebody will want to stop using Bacon in the
  * future, it will be easier */
-var lib2 = require('./lib');
-var Bacon = require('baconjs');
+var lib2 = require('./lib')
+var Bacon = require('baconjs')
 
 // this is an adapter function. it gets a Pouch changes object and it
 // returns a Bacon stream
-function changesToStream(changes, lib) {
-  return Bacon.fromBinder(function(sink) {
+function changesToStream (changes, lib) {
+  return Bacon.fromBinder(function (sink) {
     changes
-      .on('change', function(change) {
-        sink(change.doc);
+      .on('change', function (change) {
+        sink(change.doc)
       })
-      .on('error', function() {
-        sink(new Bacon.End());
+      .on('error', function () {
+        sink(new Bacon.End())
       })
-      .on('complete', function() {
-        sink(new Bacon.End());
-      });
-  });
+      .on('complete', function () {
+        sink(new Bacon.End())
+      })
+  })
 }
 
-module.exports.main = function(options, mockedLib) {
-  var lib = mockedLib || lib2;
+module.exports.main = function (options, mockedLib) {
+  var lib = mockedLib || lib2
   /* the initial configuration document is fetched from the
    * database. this is updated when a change is detected */
-  var withOptions = lib.withOptions(options);
-  function onError(err) {
-    var text = 'error on a Bacon stream';
-    lib.log.error(text);
-    lib.log.error(JSON.stringify(err));
-    withOptions.captureMessage(text, { extra: err });
+  var withOptions = lib.withOptions(options)
+  function onError (err) {
+    var text = 'error on a Bacon stream'
+    lib.log.error(text)
+    lib.log.error(JSON.stringify(err))
+    withOptions.captureMessage(text, { extra: err })
   }
   withOptions.configurationDocument
     .getInitial()
-    .then(function(firstConfigurationDocument) {
-      lib.log.debug('got configuration document '+JSON.stringify(firstConfigurationDocument));
+    .then(function (firstConfigurationDocument) {
+      lib.log.debug('got configuration document ' + JSON.stringify(firstConfigurationDocument))
       // expose for tests
-      module.exports.firstConfigurationDocument = firstConfigurationDocument;
-      var configurationDocuments = (function() {
+      module.exports.firstConfigurationDocument = firstConfigurationDocument
+      var configurationDocuments = (function () {
         /* changes feeds are wrapped into `Bacon.repeat` in order to
          * be robust to network conditions with a small timeout */
-        var stream = Bacon.repeat(function() {
-          var changes = withOptions.configurationDocument.getChanges();
-          return changesToStream(changes, lib);
-        });
+        var stream = Bacon.repeat(function () {
+          var changes = withOptions.configurationDocument.getChanges()
+          return changesToStream(changes, lib)
+        })
 
-        stream.onValue(function() {
-          lib.log.info('the configuration document changed on the database: reloading with new settings');
-          lib.log.debug(JSON.stringify(arguments));
-        });
-        stream.onError(onError);
+        stream.onValue(function () {
+          lib.log.info('the configuration document changed on the database: reloading with new settings')
+          lib.log.debug(JSON.stringify(arguments))
+        })
+        stream.onError(onError)
 
         return stream
           .toProperty()
-          .startWith(firstConfigurationDocument);
-      })();
+          .startWith(firstConfigurationDocument)
+      })()
       /* changes feeds are wrapped into `Bacon.repeat` in order to be
        * robust to network conditions with a small timeout */
-      var changes = Bacon.repeat(function() {
-        return changesToStream(withOptions.getChanges(), lib);
-      });
-      changes.onError(onError);
+      var changes = Bacon.repeat(function () {
+        return changesToStream(withOptions.getChanges(), lib)
+      })
+      changes.onError(onError)
       // the configuration document is a property, while the changes
       // are a stream. whenever a change is detected, we want to use
       // the latest configuration document. this can be achieved with
       // `property.sampledBy(stream, f)`
       var changesAndConfigurations = configurationDocuments
-            .sampledBy(changes, function(configurationDocument, change) {
-              return {
-                configurationDocument: configurationDocument,
-                change: change
-              };
-            });
+        .sampledBy(changes, function (configurationDocument, change) {
+          return {
+            configurationDocument: configurationDocument,
+            change: change
+          }
+        })
       // we convert the returned promises to streams which will be
       // concatenated by `flatMap`
-      var inlined = changesAndConfigurations.flatMap(function(obj) {
-        var promise = withOptions.inline(obj);
-        return Bacon.fromPromise(promise);
-      });
+      var inlined = changesAndConfigurations.flatMap(function (obj) {
+        var promise = withOptions.inline(obj)
+        return Bacon.fromPromise(promise)
+      })
       // for every change event we create a stream of messages to be
       // sent, then all those streams are flatted together. since we
       // are generating streams from arrays, they will be closed
       // automatically
-      var outgoing = inlined.flatMap(function(obj) {
+      var outgoing = inlined.flatMap(function (obj) {
         try {
-          var outgoingArray = lib.dispatch(obj);
-          return Bacon.fromArray(outgoingArray);
+          var outgoingArray = lib.dispatch(obj)
+          return Bacon.fromArray(outgoingArray)
         } catch (error) {
-          withOptions.captureError(error);
-          return Bacon.never();
+          withOptions.captureError(error)
+          return Bacon.never()
         }
-      });
+      })
 
-      outgoing.onValue(withOptions.sendToMobile);
-      outgoing.onError(onError);
+      outgoing.onValue(withOptions.sendToMobile)
+      outgoing.onError(onError)
 
       // export for testing
-      module.exports.changes = changes;
-      module.exports.configurationDocuments = configurationDocuments;
-      module.exports.changesAndConfigurations = changesAndConfigurations;
-      module.exports.outgoing = outgoing;
-    }, function() {
+      module.exports.changes = changes
+      module.exports.configurationDocuments = configurationDocuments
+      module.exports.changesAndConfigurations = changesAndConfigurations
+      module.exports.outgoing = outgoing
+    }, function () {
       withOptions.captureMessage('error fetching the configuration document', {
-        extra: {'promise error': JSON.stringify(arguments) }
-      });
-    });
-};
+        extra: { 'promise error': JSON.stringify(arguments) }
+      })
+    })
+}

--- a/sense-dispatch.js
+++ b/sense-dispatch.js
@@ -4,7 +4,7 @@ var yargs = require('yargs'),
     reactive = require('./reactive');
 
 var options = yargs
-      .version('0.1.0')
+      .version('0.2.0')
       .usage('Usage: $0 -d <database location> -g <gateway location>')
       .options({
         'd': {

--- a/sense-dispatch.js
+++ b/sense-dispatch.js
@@ -1,27 +1,27 @@
 #!/usr/bin/env node
 
-var yargs = require('yargs'),
-    reactive = require('./reactive');
+var yargs = require('yargs')
+var reactive = require('./reactive')
 
 var options = yargs
-      .version('0.2.0')
-      .usage('Usage: $0 -d <database location> -g <gateway location>')
-      .options({
-        'd': {
-          alias: 'database',
-          demand: true,
-          describe: 'The location of the database to be watched'
-        },
-        'g': {
-          alias: 'gateway',
-          demand: true,
-          describe: 'The location of your Telerivet Gateway'
-        },
-        'b': {
-          alias: 'debug',
-          describe: 'Add extra log message for debugging'
-        }
-      })
-      .argv;
+  .version('0.2.0')
+  .usage('Usage: $0 -d <database location> -g <gateway location>')
+  .options({
+    'd': {
+      alias: 'database',
+      demand: true,
+      describe: 'The location of the database to be watched'
+    },
+    'g': {
+      alias: 'gateway',
+      demand: true,
+      describe: 'The location of your Telerivet Gateway'
+    },
+    'b': {
+      alias: 'debug',
+      describe: 'Add extra log message for debugging'
+    }
+  })
+  .argv
 
-reactive.main(options);
+reactive.main(options)

--- a/test/init.js
+++ b/test/init.js
@@ -1,31 +1,31 @@
-var path = require('path');
-var chai = require('chai');
+var path = require('path')
+var chai = require('chai')
 
-global.assert = chai.assert;
-global.expect = chai.expect;
-chai.should();
+global.assert = chai.assert
+global.expect = chai.expect
+chai.should()
 
-(function() {
+;(function () {
   // this part is related to coverage. in the past i experienced that
   // coverage reports might suppress some exceptions, so i want to
   // disable this once in a while, just in order to be sure that there
   // are no exceptions that i am missing
-  var coverage = true;
+  var coverage = true
   if (coverage) {
-    var istanbul = require('istanbul'),
-        hook = istanbul.hook,
-        Instrumenter = istanbul.Instrumenter,
-        instrumenter = new Instrumenter();
-    var cwd = process.cwd();
-    var cwdNodeModules = path.resolve(cwd, 'node_modules');
-    var cwdTest = path.resolve(cwd, 'test');
-    var matcher = function(file) {
+    var istanbul = require('istanbul')
+    var hook = istanbul.hook
+    var Instrumenter = istanbul.Instrumenter
+    var instrumenter = new Instrumenter()
+    var cwd = process.cwd()
+    var cwdNodeModules = path.resolve(cwd, 'node_modules')
+    var cwdTest = path.resolve(cwd, 'test')
+    var matcher = function (file) {
       if (file.indexOf(cwd) !== 0 || file.indexOf(cwdNodeModules) === 0 || file.indexOf(cwdTest) === 0) {
-        return false;
+        return false
       }
-      return true;
-    };
-    var transformer = instrumenter.instrumentSync.bind(instrumenter);
-    hook.hookRequire(matcher, transformer);
+      return true
+    }
+    var transformer = instrumenter.instrumentSync.bind(instrumenter)
+    hook.hookRequire(matcher, transformer)
   }
-})();
+})()

--- a/test/main/lib.js
+++ b/test/main/lib.js
@@ -1,13 +1,13 @@
-describe('the second library', function() {
-  var lib = require('../../lib');
-  it('exports a main module object', function() {
-    lib.should.exist;
-  });
-  it('builds a withOptions object', function() {
-    lib.withOptions({ database:'test' }).should.exist;
-  });
-  describe('dispatch', function() {
-    it('dispatches', function() {
+describe('the second library', function () {
+  var lib = require('../../lib')
+  it('exports a main module object', function () {
+    lib.should.exist
+  })
+  it('builds a withOptions object', function () {
+    lib.withOptions({ database: 'test' }).should.exist
+  })
+  describe('dispatch', function () {
+    it('dispatches', function () {
       var result = lib.dispatch({
         configurationDocument: {
           template: 'A new Ebola suspect was found, the id is ${ personId }',
@@ -16,15 +16,15 @@ describe('the second library', function() {
         change: {
           personId: 'a-b-c-d'
         }
-      });
+      })
       assert.deepEqual(result, [{
         to: '1234',
         content: 'A new Ebola suspect was found, the id is a-b-c-d'
-      }]);
-    });
-    it('throws an error when a property is missing', function() {
-      assert.throws(function() {
-        var result = lib.dispatch({
+      }])
+    })
+    it('throws an error when a property is missing', function () {
+      assert.throws(function () {
+        lib.dispatch({
           configurationDocument: {
             template: 'A new Ebola suspect was found, the id is ${ persoId }',
             recipients: ['1234']
@@ -32,10 +32,10 @@ describe('the second library', function() {
           change: {
             personId: 'a-b-c-d'
           }
-        });
-      }, 'persoId is not defined');
-    });
-    it('ignores missing properties on the second level', function() {
+        })
+      }, 'persoId is not defined')
+    })
+    it('ignores missing properties on the second level', function () {
       var result = lib.dispatch({
         configurationDocument: {
           template: 'A new Ebola suspect was found, the id is ${ one.two }',
@@ -44,30 +44,30 @@ describe('the second library', function() {
         change: {
           one: {}
         }
-      });
+      })
       assert.deepEqual(result, [{
         to: '1234',
         content: 'A new Ebola suspect was found, the id is '
-      }]);
-    });
-  });
-  describe('withOptions', function() {
-    var withOptions;
-    beforeEach(function() {
+      }])
+    })
+  })
+  describe('withOptions', function () {
+    var withOptions
+    beforeEach(function () {
       withOptions = lib.withOptions({
         database: 'test'
-      });
-    });
-    it('throws an error when the database is missing', function() {
-      assert.throws(function() {
-        lib.withOptions({});
-      }, 'Pouch requires a database name');
-    });
-    it('returns an event emitter for database changes', function() {
-      withOptions.getChanges().on.should.exist;
-    });
-    it('returns an event emitter for configuration changes', function() {
-      withOptions.configurationDocument.getChanges().on.should.exist;
-    });
-  });
-});
+      })
+    })
+    it('throws an error when the database is missing', function () {
+      assert.throws(function () {
+        lib.withOptions({})
+      }, 'Pouch requires a database name')
+    })
+    it('returns an event emitter for database changes', function () {
+      withOptions.getChanges().on.should.exist
+    })
+    it('returns an event emitter for configuration changes', function () {
+      withOptions.configurationDocument.getChanges().on.should.exist
+    })
+  })
+})

--- a/test/main/lib.js
+++ b/test/main/lib.js
@@ -35,6 +35,21 @@ describe('the second library', function() {
         });
       }, 'persoId is not defined');
     });
+    it('ignores missing properties on the second level', function() {
+      var result = lib.dispatch({
+        configurationDocument: {
+          template: 'A new Ebola suspect was found, the id is ${ one.two }',
+          recipients: ['1234']
+        },
+        change: {
+          one: {}
+        }
+      });
+      assert.deepEqual(result, [{
+        to: '1234',
+        content: 'A new Ebola suspect was found, the id is '
+      }]);
+    });
   });
   describe('withOptions', function() {
     var withOptions;

--- a/test/main/libraries.js
+++ b/test/main/libraries.js
@@ -1,135 +1,137 @@
 /* i have to admit that i had to create test cases in order to be
  * absolutely sure how my libraries worked */
-var sinon = require('sinon'),
-    Q = require('q'),
-    Bacon = require('baconjs');
-describe('sampledBy', function() {
-  var stream, property;
-  beforeEach(function() {
-    stream = Bacon.fromArray([1, 2, 3]);
-    property = Bacon.constant('value');
-  });
-  it('does not output values without an initial property value', function() {
-    var spy = sinon.spy();
-    property = Bacon.fromPromise(Q.defer().promise);
-    property.sampledBy(stream).onValue(spy);
-    assert(!spy.called);
-  });
-  it('output values with a constant property', function() {
-    var spy = sinon.spy(function(a, b) {
-      return a + ' ' + b;
-    });
-    property = Bacon.constant('p');
+var sinon = require('sinon')
+var Q = require('q')
+var Bacon = require('baconjs')
+
+describe('sampledBy', function () {
+  var stream
+  var property
+  beforeEach(function () {
+    stream = Bacon.fromArray([1, 2, 3])
+    property = Bacon.constant('value')
+  })
+  it('does not output values without an initial property value', function () {
+    var spy = sinon.spy()
+    property = Bacon.fromPromise(Q.defer().promise)
+    property.sampledBy(stream).onValue(spy)
+    assert(!spy.called)
+  })
+  it('output values with a constant property', function () {
+    var spy = sinon.spy(function (a, b) {
+      return a + ' ' + b
+    })
+    property = Bacon.constant('p')
     property
       .sampledBy(stream, spy)
-      .onValue(function() {}); // just in order to flush the streams
+      .onValue(function () {}) // just in order to flush the streams
     assert.deepEqual(spy.returnValues, [
-      "p 1",
-      "p 2",
-      "p 3"
-    ]);
-  });
-  it('does not outputs values if the promise is resolved late', function() {
-    var spy = sinon.spy(),
-        deferred = Q.defer();
-    property = Bacon.fromPromise(deferred.promise);
-    property.sampledBy(stream).onValue(spy);
-    deferred.resolve('p');
-    assert.deepEqual(spy.returnValues, []);
-  });
-  it('outputs when an initial property value is given', function() {
-    var spy = sinon.spy(function(a, b) {
-      return a + ' ' + b;
-    });
-    property = Bacon.fromArray([]).toProperty().startWith('p');
+      'p 1',
+      'p 2',
+      'p 3'
+    ])
+  })
+  it('does not outputs values if the promise is resolved late', function () {
+    var spy = sinon.spy()
+    var deferred = Q.defer()
+    property = Bacon.fromPromise(deferred.promise)
+    property.sampledBy(stream).onValue(spy)
+    deferred.resolve('p')
+    assert.deepEqual(spy.returnValues, [])
+  })
+  it('outputs when an initial property value is given', function () {
+    var spy = sinon.spy(function (a, b) {
+      return a + ' ' + b
+    })
+    property = Bacon.fromArray([]).toProperty().startWith('p')
     property
       .sampledBy(stream, spy)
-      .onValue(function() {}); // just in order to flush the streams
+      .onValue(function () {}) // just in order to flush the streams
     assert.deepEqual(spy.returnValues, [
-      "p 1",
-      "p 2",
-      "p 3"
-    ]);
-  });
-  it('gives us the initial property value', function() {
-    var spy = sinon.spy();
-    property = Bacon.fromArray([]).toProperty().startWith('p');
-    property.onValue(spy);
-    assert.deepEqual(spy.args[0], ['p']);
-  });
-  it('samples also without a combining function', function() {
-    var spy = sinon.spy();
-    property = Bacon.fromArray([]).toProperty().startWith('p');
-    property.sampledBy(stream).onValue(spy);
-    assert.deepEqual(spy.args.length, 3);
-  });
-  it('picks the last property value available', function() {
-    var spy = sinon.spy(function(a, b) {
-      return a + ' ' + b;
-    });
-    property = Bacon.fromArray(['p2','p3']).toProperty().startWith('p1');
+      'p 1',
+      'p 2',
+      'p 3'
+    ])
+  })
+  it('gives us the initial property value', function () {
+    var spy = sinon.spy()
+    property = Bacon.fromArray([]).toProperty().startWith('p')
+    property.onValue(spy)
+    assert.deepEqual(spy.args[0], ['p'])
+  })
+  it('samples also without a combining function', function () {
+    var spy = sinon.spy()
+    property = Bacon.fromArray([]).toProperty().startWith('p')
+    property.sampledBy(stream).onValue(spy)
+    assert.deepEqual(spy.args.length, 3)
+  })
+  it('picks the last property value available', function () {
+    var spy = sinon.spy(function (a, b) {
+      return a + ' ' + b
+    })
+    property = Bacon.fromArray(['p2', 'p3']).toProperty().startWith('p1')
     property
       .sampledBy(stream, spy)
-      .onValue(function() {}); // just in order to flush the streams
+      .onValue(function () {}) // just in order to flush the streams
     assert.deepEqual(spy.returnValues, [
-      "p3 1",
-      "p3 2",
-      "p3 3"
-    ]);
-  });
-});
-describe('flatMap', function() {
-  it('concatenates results as expected', function() {
-    var stream = Bacon.fromArray(['a', 'b']);
-    var spy = sinon.spy();
+      'p3 1',
+      'p3 2',
+      'p3 3'
+    ])
+  })
+})
+describe('flatMap', function () {
+  it('concatenates results as expected', function () {
+    var stream = Bacon.fromArray(['a', 'b'])
+    var spy = sinon.spy()
     stream
-      .flatMap(function(letter) {
-        var array = [1, 2].map(function(number) {
-          return letter + ' ' + number;
-        });
-        return Bacon.fromArray(array);
+      .flatMap(function (letter) {
+        var array = [1, 2].map(function (number) {
+          return letter + ' ' + number
+        })
+        return Bacon.fromArray(array)
       })
-      .onValue(spy);
+      .onValue(spy)
     assert.deepEqual(spy.args, [
       ['a 1'],
       ['a 2'],
       ['b 1'],
       ['b 2']
-    ]);
-  });
-});
-describe('testing a deferred', function() {
-  it('does not work as i initially expected', function() {
-    var spy = sinon.spy();
-    var deferred = Q.defer();
-    deferred.promise.then(spy);
-    deferred.resolve('value');
-    assert(deferred.promise.isFulfilled());
-    assert(!spy.called);
-  });
-  it('needs to be done, for example, this way', function(done) {
-    var spy = sinon.spy();
-    var deferred = Q.defer();
+    ])
+  })
+})
+describe('testing a deferred', function () {
+  it('does not work as i initially expected', function () {
+    var spy = sinon.spy()
+    var deferred = Q.defer()
+    deferred.promise.then(spy)
+    deferred.resolve('value')
+    assert(deferred.promise.isFulfilled())
+    assert(!spy.called)
+  })
+  it('needs to be done, for example, this way', function (done) {
+    var spy = sinon.spy()
+    var deferred = Q.defer()
     deferred.promise
       .then(spy)
-      .then(function() {
-        assert(spy.calledWith('value'));
+      .then(function () {
+        assert(spy.calledWith('value'))
       })
-      .then(done);
-    deferred.resolve('value');
-  });
-});
-describe('event emitters', function() {
-  var events = require('events'),
-      emitter,
-      spy;
-  beforeEach(function() {
-    emitter = new events.EventEmitter();
-    spy = sinon.spy();
-    emitter.on('event', spy);
-    emitter.emit('event');
-  });
-  it('evaluate synchronously, no need to use `done` with Mocha', function() {
-    assert(spy.called);
-  });
-});
+      .then(done)
+    deferred.resolve('value')
+  })
+})
+describe('event emitters', function () {
+  var events = require('events')
+  var emitter
+  var spy
+  beforeEach(function () {
+    emitter = new events.EventEmitter()
+    spy = sinon.spy()
+    emitter.on('event', spy)
+    emitter.emit('event')
+  })
+  it('evaluate synchronously, no need to use `done` with Mocha', function () {
+    assert(spy.called)
+  })
+})

--- a/test/main/reactive.js
+++ b/test/main/reactive.js
@@ -1,156 +1,154 @@
-/* jshint camelcase: false */ // for doc_type
-/* jshint newcap: false */ // for Q()
-
-describe('the reactive logic', function() {
-  var Bacon = require('baconjs');
-  var reactive, main;
-  beforeEach(function() {
-    reactive = require('../../reactive');
-    main = reactive.main;
-  });
-  it('exports a main module object', function() {
-    main.should.be.a('function');
-  });
-  describe('with a mocked library', function() {
-    var sinon = require('sinon');
-    var events = require('events');
-    var Q, deferred, emitters, withOptions, lib;
-    beforeEach(function() {
-      function constant(val) {
-        return function() {
-          return val;
-        };
+describe('the reactive logic', function () {
+  var Bacon = require('baconjs')
+  var reactive, main
+  beforeEach(function () {
+    reactive = require('../../reactive')
+    main = reactive.main
+  })
+  it('exports a main module object', function () {
+    main.should.be.a('function')
+  })
+  describe('with a mocked library', function () {
+    var sinon = require('sinon')
+    var events = require('events')
+    var Q, deferred, emitters, withOptions, lib
+    beforeEach(function () {
+      function constant (val) {
+        return function () {
+          return val
+        }
       }
-      Q = require('q');
-      deferred = Q.defer();
+      Q = require('q')
+      deferred = Q.defer()
       emitters = {
         configurationDocument: new events.EventEmitter(),
         changes: new events.EventEmitter()
-      };
+      }
       withOptions = {
         configurationDocument: {
           getInitial: constant(deferred.promise),
           getChanges: constant(emitters.configurationDocument)
         },
         getChanges: constant(emitters.changes),
-        inline: function(a) { return Q(a); },
+        inline: function (a) { return Q(a) },
         sendToMobile: sinon.spy(),
         captureError: sinon.spy()
-      };
+      }
       // we need to do this before passing `withOptions` to `constant`
-      sinon.spy(withOptions, 'getChanges');
+      sinon.spy(withOptions, 'getChanges')
       lib = {
         withOptions: constant(withOptions),
-        dispatch: sinon.spy(function() { return [1, 2, 3]; }),
+        dispatch: sinon.spy(function () { return [1, 2, 3] }),
         captureMessage: sinon.spy(),
         log: {
-          info: function(){},
-          debug: function(){}
+          info: function () {},
+          debug: function () {}
         }
-      };
-    });
-    afterEach(function() {
-      assert(!lib.captureMessage.called, 'there are no errors catched');
-    });
-    it('waits the promise without throwing exceptions', function() {
-      assert.doesNotThrow(function() {
-        main({}, lib);
-      });
-    });
-    it('is correctly spied', function() {
-      assert(!withOptions.getChanges.called);
-      lib.withOptions().getChanges();
-      assert(withOptions.getChanges.called);
-    });
-    describe('with a document configuration', function() {
-      beforeEach(function(done) {
-        main({}, lib);
-        deferred.resolve({conf: 'doc'});
-        deferred.promise.finally(done);
-      });
-      it('got a first configuration document', function() {
-        assert.deepEqual(reactive.firstConfigurationDocument, {conf: 'doc'});
-      });
-      it('has a conf object', function() {
-        var spy = sinon.spy();
-        reactive.configurationDocuments.onValue(spy);
-        assert.deepEqual(spy.args[0], [{conf:'doc'}]);
-      });
-      it('asks for changes', function() {
-        assert(withOptions.getChanges.called);
-      });
-      it('allows the configuration to be sampled', function() {
-        var stream = Bacon.fromArray([1, 2, 3]);
-        var spy = sinon.spy();
-        reactive.configurationDocuments.sampledBy(stream).onValue(spy);
-        assert.equal(spy.args.length, 3);
-      });
-      describe('with a faulty `dispatch`, on a document change', function() {
-        var error;
-        beforeEach(function(done) {
-          error = new Error('dispatch error');
-          lib.dispatch = function() { throw(error); };
-          emitters.changes.emit('change', {});
+      }
+    })
+    afterEach(function () {
+      assert(!lib.captureMessage.called, 'there are no errors catched')
+    })
+    it('waits the promise without throwing exceptions', function () {
+      assert.doesNotThrow(function () {
+        main({}, lib)
+      })
+    })
+    it('is correctly spied', function () {
+      assert(!withOptions.getChanges.called)
+      lib.withOptions().getChanges()
+      assert(withOptions.getChanges.called)
+    })
+    describe('with a document configuration', function () {
+      beforeEach(function (done) {
+        main({}, lib)
+        deferred.resolve({conf: 'doc'})
+        deferred.promise.finally(done)
+      })
+      it('got a first configuration document', function () {
+        assert.deepEqual(reactive.firstConfigurationDocument, {conf: 'doc'})
+      })
+      it('has a conf object', function () {
+        var spy = sinon.spy()
+        reactive.configurationDocuments.onValue(spy)
+        assert.deepEqual(spy.args[0], [{conf: 'doc'}])
+      })
+      it('asks for changes', function () {
+        assert(withOptions.getChanges.called)
+      })
+      it('allows the configuration to be sampled', function () {
+        var stream = Bacon.fromArray([1, 2, 3])
+        var spy = sinon.spy()
+        reactive.configurationDocuments.sampledBy(stream).onValue(spy)
+        assert.equal(spy.args.length, 3)
+      })
+      describe('with a faulty `dispatch`, on a document change', function () {
+        var error
+        beforeEach(function (done) {
+          error = new Error('dispatch error')
+          lib.dispatch = function () { throw error }
+          emitters.changes.emit('change', {})
           // there are some Q promises along the way, which would lead
           // to a failure if we evaluated this synchronously, so let
           // us take some time
-          Q.delay(100).then(done);
-        });
-        it('is called', function() {
-          assert(withOptions.captureError.called);
-        });
-        it('logs the error', function() {
-          assert.deepEqual(withOptions.captureError.args, [[error]]);
-        });
-      });
-      describe('on a document change', function() {
-        var hadListeners, changesSpy, changesAndConfigurationsSpy;
-        var change = {
-          seq: 4961,
-          id: 'some id',
-          changes: [ {} ],
-          doc: {
-            _id: 'some id',
-            _rev: '1-e95541d309722ef8626c9c992880e226',
-            comment: '',
-            appVersion: '4.1.0',
-            dateOfVisit: '2015-06-30T11:30:29.273Z',
-            deviceId: 'e1ecb015c869148b',
-            symptoms: {},
-            geoInfo: {},
-            interviewer: [Object],
-            personId: '214119b8-98fb-43ae-b317-aa00c3ae559c',
-            doc_type: 'followup',
-            version: '1.19.0'
-          }
-        };
-        beforeEach(function(done) {
-          changesSpy = sinon.spy();
-          changesAndConfigurationsSpy = sinon.spy();
-          reactive.changes.onValue(changesSpy);
-          reactive.changesAndConfigurations.onValue(changesAndConfigurationsSpy);
-          hadListeners = emitters.changes.emit('change', {});
+          Q.delay(100).then(done)
+        })
+        it('is called', function () {
+          assert(withOptions.captureError.called)
+        })
+        it('logs the error', function () {
+          assert.deepEqual(withOptions.captureError.args, [[error]])
+        })
+      })
+      describe('on a document change', function () {
+        var hadListeners, changesSpy, changesAndConfigurationsSpy
+        // This isn't used anywhere...
+        // var change = {
+        //   seq: 4961,
+        //   id: 'some id',
+        //   changes: [ {} ],
+        //   doc: {
+        //     _id: 'some id',
+        //     _rev: '1-e95541d309722ef8626c9c992880e226',
+        //     comment: '',
+        //     appVersion: '4.1.0',
+        //     dateOfVisit: '2015-06-30T11:30:29.273Z',
+        //     deviceId: 'e1ecb015c869148b',
+        //     symptoms: {},
+        //     geoInfo: {},
+        //     interviewer: [Object],
+        //     personId: '214119b8-98fb-43ae-b317-aa00c3ae559c',
+        //     doc_type: 'followup',
+        //     version: '1.19.0'
+        //   }
+        // }
+        beforeEach(function (done) {
+          changesSpy = sinon.spy()
+          changesAndConfigurationsSpy = sinon.spy()
+          reactive.changes.onValue(changesSpy)
+          reactive.changesAndConfigurations.onValue(changesAndConfigurationsSpy)
+          hadListeners = emitters.changes.emit('change', {})
           // there are some Q promises along the way, which would lead
           // to a failure if we evaluated this synchronously, so let
           // us take some time
-          Q.delay(100).then(done);
-        });
-        it('had listeners', function() {
-          assert(hadListeners);
-        });
-        it('sent changes', function() {
-          assert(changesSpy.called, 'called the changes spy');
-        });
-        it('sent changes and configuration', function() {
-          assert(changesAndConfigurationsSpy.called, 'called the changes and configuration spy');
-        });
-        it('dispatches', function() {
-          assert(lib.dispatch.called, 'called dispatch');
-        });
-        it('sends a message', function() {
-          assert(withOptions.sendToMobile.called, 'called sendToMobile');
-        });
-      });
-    });
-  });
-});
+          Q.delay(100).then(done)
+        })
+        it('had listeners', function () {
+          assert(hadListeners)
+        })
+        it('sent changes', function () {
+          assert(changesSpy.called, 'called the changes spy')
+        })
+        it('sent changes and configuration', function () {
+          assert(changesAndConfigurationsSpy.called, 'called the changes and configuration spy')
+        })
+        it('dispatches', function () {
+          assert(lib.dispatch.called, 'called dispatch')
+        })
+        it('sends a message', function () {
+          assert(withOptions.sendToMobile.called, 'called sendToMobile')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
I ran `standard --format` over https://github.com/eHealthAfrica/sense-dispatch/pull/6 and fixed up the remaining stuff manually.  Added `standard` to the `npm test` script and added some common globals via the `standard` property in `package.json` Picked up a couple of bugs (undefined `err` params in error callbacks), and highlighted some other stuff (like this; https://github.com/eHealthAfrica/sense-dispatch/pull/6)

:dancers: 
